### PR TITLE
Make openlabcmd -c option work

### DIFF
--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -4,7 +4,12 @@ This is the command line tool for OpenLab management.
 
 ## How to use
 
-You can install from source or just use `pip install openlabcmd`. 
+You can install from source or just use `pip install openlabcmd`.
+
+Before use `openlabcmd`, you should create or update the config file
+`openlab.conf`. Use `-c` to specified one. The tool will try to find
+the file in paths `/etc/openlab/openlab.conf`, `~/openlab.conf` and
+`/usr/local/etc/openlab/openlab.conf` if it's not provided by user.
 
 ## Supported features
 

--- a/openlabcmd/etc/openlab.conf
+++ b/openlabcmd/etc/openlab.conf
@@ -1,0 +1,4 @@
+[check]
+cloud_conf = /etc/openstack/clouds.yaml
+
+[ha]

--- a/openlabcmd/setup.cfg
+++ b/openlabcmd/setup.cfg
@@ -15,6 +15,10 @@ classifier =
 [pbr]
 warnerrors = True
 
+[files]
+data_files =
+    etc/openlab = etc/openlab.conf
+
 [entry_points]
 console_scripts =
     openlab = openlabcmd.cli:main


### PR DESCRIPTION
openlab.conf works now. Use `openlab -c` to specified the config file.