### PR TITLE
Correct the time of labsync cron tasks

### DIFF
--- a/playbooks/sync-config-files.yaml
+++ b/playbooks/sync-config-files.yaml
@@ -74,6 +74,7 @@
     - name: Add crontab task to sync files for nodepool
       cron:
         name: "labsync nodepool config files"
+        minute: "0"
         hour: "1"
         job: "bash /home/ubuntu/nodepool_files_sync.sh {{ github_username }} {{ github_useremail }} {{ github_token }} >> /var/log/sync.log 2>&1"
 
@@ -94,5 +95,6 @@
     - name: Add crontab task to sync files for zuul
       cron:
         name: "labsync zuul config files"
+        minute: "0"
         hour: "0"
         job: "bash /home/ubuntu/zuul_files_sync.sh {{ github_username }} {{ github_useremail }} {{ github_token }} >> /var/log/sync.log 2>&1"


### PR DESCRIPTION
We wish labsync tasks running at utc 0:00 and 1:00,
but the cron time configured wrong, fix it.

Related: theopenlab/openlab#84