### PR TITLE
Add update_service func

### DIFF
--- a/openlabcmd/openlabcmd/exceptions.py
+++ b/openlabcmd/openlabcmd/exceptions.py
@@ -1,2 +1,6 @@
 class ClientError(Exception):
     pass
+
+
+class ValidationError(Exception):
+    pass

--- a/openlabcmd/openlabcmd/node.py
+++ b/openlabcmd/openlabcmd/node.py
@@ -10,17 +10,14 @@ class NodeStatus(object):
 
 class Node(object):
     def __init__(self, name, role, type, ip, heartbeat=None, alarmed=None,
-                 status=None):
+                 status=None, **kwargs):
         self.name = name
         self.role = role
         self.type = type
         self.ip = ip
-        if not heartbeat:
-            self.heartbeat = 0
-        if not alarmed:
-            self.alarmed = False
-        if not status:
-            self.status = NodeStatus.INITIALIZING
+        self.heartbeat = heartbeat or 0
+        self.alarmed = alarmed or False
+        self.status = status or NodeStatus.INITIALIZING
 
     def to_zk_data(self):
         node_dict = {
@@ -34,7 +31,6 @@ class Node(object):
         }
         return json.dumps(node_dict).encode('utf8')
 
-    @classmethod
-    def from_dict(cls, name, role, n_type, ip, heartbeat=None, alarmed=None,
-                  status=None):
-        return cls(name, role, n_type, ip, heartbeat, alarmed, status)
+    @ classmethod
+    def from_dict(cls, d):
+        return cls(**d)

--- a/openlabcmd/openlabcmd/service.py
+++ b/openlabcmd/openlabcmd/service.py
@@ -26,27 +26,31 @@ class ServiceStatus(object):
     INITIALIZING = 'initializing'
     UP = 'up'
     DOWN = 'down'
-    Restarting = 'restarting'
+    RESTARTING = 'restarting'
+
+    @property
+    def all_status(self):
+        return [self.INITIALIZING, self.UP, self.DOWN, self.RESTARTING]
 
 
 class Service(object):
-    def __init__(self, name, node_role):
+    def __init__(self, name, node_role, alarmed=None, alarmed_at=None,
+                 restarted=None, restarted_at=None, is_necessary=None,
+                 status=None, **kwargs):
         self.name = name
-        self.alarmed = False
-        self.alarmed_at = None
-        self.updated_at = None
-        self.restarted = False
-        self.restarted_at = None
-        self.is_necessary = None
         self.node_role = node_role
-        self.status = ServiceStatus.INITIALIZING
+        self.alarmed = alarmed or False
+        self.alarmed_at = alarmed_at
+        self.restarted = restarted or False
+        self.restarted_at = restarted_at
+        self.is_necessary = is_necessary
+        self.status = status or ServiceStatus.INITIALIZING
 
     def to_zk_data(self):
         node_dict = {
             'name': self.name,
             'alarmed': self.alarmed,
             'alarmed_at': self.alarmed_at,
-            'updated_at': self.updated_at,
             'restarted': self.restarted,
             'restarted_at': self.restarted_at,
             'is_necessary': self.is_necessary,
@@ -54,6 +58,10 @@ class Service(object):
             'status': self.status
         }
         return json.dumps(node_dict).encode('utf8')
+
+    @ classmethod
+    def from_dict(cls, d):
+        return cls(**d)
 
 
 class NecessaryService(Service):

--- a/openlabcmd/openlabcmd/utils.py
+++ b/openlabcmd/openlabcmd/utils.py
@@ -32,6 +32,7 @@ _headers_table_mapping = {
     ]),
     'service': OrderedDict([
         ("name", "Name"),
+        ("node_name", "Node_Name"),
         ("node_role", "Node_Role"),
         ("alarmed", "Alarmed"),
         ("alarmed_at", "Alarmed_At"),


### PR DESCRIPTION
1. Add update_service func which will be used by keepalived. Note that this is not for operators so that we won't expose cli.

2. Fixed the bug that service's updated_at is always None.

3. Fixed the bug that the service's node role is always the same.

4. Fixed the bug that `node set` cli doesn't work.

5. Add `node_name_filter` and `node_role_filter` for `list_services` function

6. Expose `node_name` for service cmds.