### PR TITLE
openlabcmd py3 support

### DIFF
--- a/openlabcmd/openlabcmd/plugins/base.py
+++ b/openlabcmd/openlabcmd/plugins/base.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 import six
 
 from openlabcmd.plugins.recover import RECOVER_MAPS
@@ -97,7 +97,7 @@ class Plugin(object):
         for r_code in self.reasons:
             if r_code in RECOVER_MAPS:
                 recover_cmd = RECOVER_MAPS[r_code]['recover'] % self.cloud
-                ret, res = commands.getstatusoutput(recover_cmd)
+                ret, res = subprocess.getstatusoutput(recover_cmd)
                 if not ret:
                     self._print_recover_line(True, recover_cmd)
                 else:

--- a/openlabcmd/openlabcmd/plugins/jobs/image.py
+++ b/openlabcmd/openlabcmd/plugins/jobs/image.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 from openlabcmd.plugins.base import Plugin
 
@@ -14,7 +14,7 @@ class ImagePlugin(Plugin):
         # find 'cirros' in openstack image list
         image_check = 'openstack --os-cloud %s image list ' \
                       '-c "Name" -c "Status" -f value | grep cirros' % self.cloud
-        res = commands.getoutput(image_check)
+        res = subprocess.getoutput(image_check)
         if "cirros" not in res:
             self.failed = True
             self.reasons.append("- Image: cirros image not found.")

--- a/openlabcmd/openlabcmd/plugins/nodepool/auth.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/auth.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 from openlabcmd.plugins.base import Plugin
 
@@ -13,7 +13,7 @@ class AuthPlugin(Plugin):
         self.reasons = []
 
         auth_check = 'openstack --os-cloud %s token issue -f value -c id' % self.cloud
-        res = commands.getoutput(auth_check)
+        res = subprocess.getoutput(auth_check)
         if "HTTP 401" in res or "not found" in res:
             self.failed = True
             self.reasons.append(res)

--- a/openlabcmd/openlabcmd/plugins/nodepool/flavor.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/flavor.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 import yaml
 
@@ -13,7 +13,7 @@ class FlavorPlugin(Plugin):
         self.failed = False
         self.reasons = []
         sg = 'openstack --os-cloud %s flavor list -f yaml -c VCPUs -c RAM -c Disk -c Name' % self.cloud
-        res = commands.getoutput(sg)
+        res = subprocess.getoutput(sg)
         flavors = yaml.load(res, Loader=yaml.FullLoader)
 
         # Find 4U8G, 8U8G, 1U2G, 2U2G flavor

--- a/openlabcmd/openlabcmd/plugins/nodepool/network.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/network.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 from openlabcmd.plugins.base import Plugin
 from openlabcmd.plugins.recover import Recover
@@ -12,7 +12,7 @@ class NetworkPlugin(Plugin):
         self.failed = False
         self.reasons = []
         net = 'openstack --os-cloud %s network show openlab-net' % self.cloud
-        ret, res = commands.getstatusoutput(net)
+        ret, res = subprocess.getstatusoutput(net)
         if ret != 0:
             self.failed = True
             if "More than one Network exists" in res:
@@ -24,7 +24,7 @@ class NetworkPlugin(Plugin):
 
         subnet = 'openstack --os-cloud %s subnet list --network openlab-net ' \
                  '-f value -c Name -c Subnet' % self.cloud
-        ret, res = commands.getstatusoutput(subnet)
+        ret, res = subprocess.getstatusoutput(subnet)
         if ret != 0 and "More than one Subnet exists" in res:
             self.failed = True
             self.reasons.append(res)

--- a/openlabcmd/openlabcmd/plugins/nodepool/quota.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/quota.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 from openlabcmd.plugins.base import Plugin
 
@@ -15,6 +15,6 @@ class QuotaPlugin(Plugin):
         # print basic quota info
         quota = 'openstack --os-cloud %s quota show -f yaml ' \
                 '-c cores -c ram -c volumes -c networks -c subnets -c floating-ips' % self.cloud
-        res = commands.getoutput(quota)
+        res = subprocess.getoutput(quota)
 
         self.reasons.append(res)

--- a/openlabcmd/openlabcmd/plugins/nodepool/securitygroup.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/securitygroup.py
@@ -1,4 +1,4 @@
-import commands
+import subprocess
 
 from openlabcmd.plugins.base import Plugin
 from openlabcmd.plugins.recover import Recover
@@ -13,7 +13,7 @@ class SecurityGroupPlugin(Plugin):
         self.failed = False
         self.reasons = []
         sg = 'openstack --os-cloud %s security group show openlab-sg' % self.cloud
-        ret, res = commands.getstatusoutput(sg)
+        ret, res = subprocess.getstatusoutput(sg)
         if ret != 0:
             self.failed = True
             if "More than one SecurityGroup exists" in res:
@@ -29,7 +29,7 @@ class SecurityGroupPlugin(Plugin):
         --ingress -f value \
         -c "IP Protocol" -c "IP Range" -c "Port Range" -c "Ethertype" -c "Remote Security Group" \
         |grep 0.0.0.0 |grep None' % self.cloud
-        res = commands.getoutput(tcp_rule)
+        res = subprocess.getoutput(tcp_rule)
         if "tcp 0.0.0.0/0 19885:19885 None" not in res:
             self.failed = True
             self.reasons.append(Recover.SECURITY_GROUP_19885)

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -319,10 +319,10 @@ class ZooKeeper(object):
             old_service['restarted'] = restarted
             old_service['restarted_at'] = current_time
         if status:
-            if status not in service.ServiceStatus.all_status:
+            if status not in service.ServiceStatus().all_status:
                 raise exceptions.ValidationError(
                     'status should be in %s.' %
-                    service.ServiceStatus.all_status)
+                    service.ServiceStatus().all_status)
             old_service['status'] = status
 
         old_service.update(kwargs)

--- a/openlabcmd/requirements.txt
+++ b/openlabcmd/requirements.txt
@@ -1,4 +1,5 @@
-pbr>=1.3
-PyYAML>=5.1
+enum;python_version=='2.7'
 kazoo
+pbr>=1.3
 prettytable
+PyYAML>=5.1

--- a/openlabcmd/setup.cfg
+++ b/openlabcmd/setup.cfg
@@ -11,6 +11,10 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
 
 [pbr]
 warnerrors = True


### PR DESCRIPTION
1. Remove `commands` lib usage.
2. Add `enum` requirement only for py2.