### PR TITLE
Use forked repo as labsync working repo

### DIFF
--- a/labsync/nodepool_files_sync.sh
+++ b/labsync/nodepool_files_sync.sh
@@ -37,7 +37,12 @@ hub pull
 modify_time=`date +%Y%m%d%H%M`
 branch_name="update${modify_time}"
 message="[Nodepool_Sync] Sync_${modify_time}_modified_by_${github_username}"
-hub checkout -b ${branch_name}
+hub remote update
+# sync update for forked repo
+hub merge upstream/master
+hub push origin
+# checkout a new branch based on upstream
+hub checkout -b ${branch_name} upstream/master
 
 # update files
 cp /home/ubuntu/vault-password.txt vault-password.txt

--- a/labsync/sync_prepare.sh
+++ b/labsync/sync_prepare.sh
@@ -26,11 +26,12 @@ function pull_and_config_labkeeper()
     fi
     if [ ! -d ~/inotify/labkeeper/ ];then
         echo "pull labkeeper repo"
-        hub clone https://github.com/theopenlab/labkeeper ~/inotify/labkeeper
+        hub clone https://github.com/theopenlab-ci/labkeeper ~/inotify/labkeeper
         echo "clone labkeeper repo success!"
         cd ~/inotify/labkeeper
         hub config user.name ${github_username}
         hub config user.email ${github_useremail}
+        hub remote add upstream  https://github.com/theopenlab/labkeeper
         echo "pull and config labkeeper success!"
     fi
     echo "The repo labkeeper is already there!"

--- a/labsync/zuul_files_sync.sh
+++ b/labsync/zuul_files_sync.sh
@@ -34,7 +34,12 @@ hub pull
 modify_time=`date +%Y%m%d%H%M`
 branch_name="update${modify_time}"
 message="[Zuul_Sync] Sync_${modify_time}_modified_by_${github_username}"
-hub checkout -b ${branch_name}
+hub remote update
+# sync update for forked repo
+hub merge upstream/master
+hub push origin
+# checkout a new branch based on upstream
+hub checkout -b ${branch_name} upstream/master
 echo "copy file to labkeeper"
 cp /etc/zuul/main.yaml $online_file
 


### PR DESCRIPTION
Change to use forked repo http://github.com/theopenlab-ci/labkeeper
as labsync working repo to avoid creating branches on
http://github.com/theopenlab/labkeeper.

Related-Bug: theopenlab/openlab#84