### PR TITLE
Add ha initializtion step for HA mode

### DIFF
--- a/etc/openlabcmd/openlab.conf.j2
+++ b/etc/openlabcmd/openlab.conf.j2
@@ -1,0 +1,5 @@
+[check]
+cloud_conf = /etc/openstack/clouds.yaml
+
+[ha]
+zookeeper_hosts = {{ groups['zookeeper'] | map('extract', hostvars, 'ansible_host') | join(', ') }}

--- a/inventory/openlab-ha.yaml
+++ b/inventory/openlab-ha.yaml
@@ -36,6 +36,16 @@ all:
               hosts: nodepool02
               vars:
                 nodepool_service_nodepool_launcher_state: stopped
+        nodepool-master:
+          hosts: nodepool01
+          vars:
+            node_role: "master"
+            node_type: "nodepool"
+        nodepool-slave:
+          hosts: nodepool02
+          vars:
+            node_role: "slave"
+            node_type: "nodepool"
       vars:
         nodepool_file_nodepool_yaml_src: "{{ labkeeper_config_git_dest }}/nodepool/openlab-nodepool.yaml.j2"
         nodepool_clouds_src: "{{ labkeeper_config_git_dest }}/nodepool/openlab-clouds.yaml.j2"
@@ -90,10 +100,14 @@ all:
         zuul-master:
           hosts: zuul01
           vars:
+            node_role: "master"
+            node_type: "zuul"
             zuul_public_ip: 10.3.0.1
         zuul-slave:
           hosts: zuul02
           vars:
+            node_role: "slave"
+            node_type: "zuul"
             zuul_public_ip: 10.3.0.2
       vars:
         github_app_id: 6778
@@ -141,6 +155,8 @@ all:
         zk-03:
           hosts: zk03
           vars:
+            node_role: "zookeeper"
+            node_type: "zookeeper"
             zk_myid: 3
     mysql:
       children:

--- a/openlabcmd/etc/openlab.conf
+++ b/openlabcmd/etc/openlab.conf
@@ -2,3 +2,4 @@
 cloud_conf = /etc/openstack/clouds.yaml
 
 [ha]
+zookeeper_hosts = localhost

--- a/playbooks/ha_openlabcmd_install.yaml
+++ b/playbooks/ha_openlabcmd_install.yaml
@@ -1,0 +1,20 @@
+---
+- name: Install and config openlabcmd
+  hosts: nodepool-master, nodepool-slave, zuul-master, zuul-slave, zk03
+  become: yes
+  tasks:
+    - name: Install openlabcmd
+      pip:
+        name: openlabcmd
+
+    - name: Config openlabcmd
+      template:
+        src: "{{ labkeeper_config_git_dest }}/openlabcmd/openlab.conf.j2"
+        dest: /etc/openlab/openlab.conf
+
+    - name: Init HA node
+      shell: |
+        openlab ha node init --role '{{ node_role }}' --type  '{{ node_type }}' \
+        --ip '{{ hostvars[inventory_hostname]['ansible_host'] }}' $(hostname)
+      args:
+        executable: /bin/bash

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -29,6 +29,7 @@
 - import_playbook: zuul-web.yaml
 - import_playbook: zuul-log-server.yaml
 - import_playbook: ha_log_cfg_sync.yaml
+- import_playbook: ha_openlabcmd_install.yaml
 - import_playbook: apache.yaml
 - import_playbook: keepalived.yaml
 - import_playbook: sync-config-files.yaml


### PR DESCRIPTION
When deploy openlab environment for ha mode. We should install openlabcmd and initialize the node info as well.