### PR TITLE
Refactor `service get` cmd

### DIFF
--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -97,14 +97,12 @@ Get or list the service running in cluster.
 * openlab ha service list
 * openlab ha service get
   ```
-  usage: openlab ha service get [-h] [--role {master,slave,zookeeper}] name
+  usage: openlab ha service get [-h] --node NODE name
 
   positional arguments:
     name                  service name.
 
   optional arguments:
     -h, --help            show this help message and exit
-    --role {master,slave,zookeeper}
-                          The role of the node where the service run. It must be
-                          sepcified if the service is 'mysql' or 'zookeeper'.
+    --node NODE  The node where the service run.
   ```

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -138,11 +138,7 @@ class OpenLabCmd(object):
         cmd_ha_service_get.set_defaults(func=self.ha_service_get)
         cmd_ha_service_get.add_argument('name', help='service name.')
         cmd_ha_service_get.add_argument(
-            '--role', required=True, choices=['master', 'slave', 'zookeeper'],
-            help="The role of the node where the service run.")
-        cmd_ha_service_get.add_argument(
-            '--type', required=True, choices=['zuul', 'nodepool', 'zookeeper'],
-            help="The type of the node where the service run.")
+            '--node', required=True, help="The node where the service run.")
 
     def _add_ha_cmd(self, parser):
         # openlab ha
@@ -290,8 +286,7 @@ class OpenLabCmd(object):
 
     @_zk_wrapper
     def ha_service_get(self):
-        result = self.zk.get_service(self.args.name.lower(), self.args.role,
-                                     self.args.type)
+        result = self.zk.get_service(self.args.name.lower(), self.args.node)
         if self.args.format == 'pretty':
             print(utils.format_output('service', result))
         else:

--- a/openlabcmd/openlabcmd/service.py
+++ b/openlabcmd/openlabcmd/service.py
@@ -50,12 +50,11 @@ class ServiceStatus(object):
 
 
 class Service(object):
-    def __init__(self, name, node_role, node_name=None, alarmed=None,
+    def __init__(self, name, node_name, alarmed=None,
                  alarmed_at=None, restarted=None, restarted_at=None,
                  is_necessary=None, status=None, created_at=None,
                  updated_at=None, **kwargs):
         self.name = name
-        self.node_role = node_role
         self.node_name = node_name
         self.alarmed = alarmed or False
         self.alarmed_at = alarmed_at
@@ -69,7 +68,6 @@ class Service(object):
     def to_zk_bytes(self):
         node_dict = {
             'name': self.name,
-            'node_role': self.node_role,
             'node_name': self.node_name,
             'alarmed': self.alarmed,
             'alarmed_at': self.alarmed_at,
@@ -99,12 +97,12 @@ class Service(object):
 
 
 class NecessaryService(Service):
-    def __init__(self, name, node_role, node_name):
-        super(NecessaryService, self).__init__(name, node_role, node_name)
+    def __init__(self, name, node_name):
+        super(NecessaryService, self).__init__(name, node_name)
         self.is_necessary = True
 
 
 class UnnecessaryService(Service):
-    def __init__(self, name, node_role, node_name):
-        super(UnnecessaryService, self).__init__(name, node_role, node_name)
+    def __init__(self, name, node_name):
+        super(UnnecessaryService, self).__init__(name, node_name)
         self.is_necessary = False

--- a/openlabcmd/openlabcmd/utils.py
+++ b/openlabcmd/openlabcmd/utils.py
@@ -33,14 +33,13 @@ _headers_table_mapping = {
     'service': OrderedDict([
         ("name", "Name"),
         ("node_name", "Node_Name"),
-        ("node_role", "Node_Role"),
         ("alarmed", "Alarmed"),
         ("alarmed_at", "Alarmed_At"),
-        ("updated_at", "Updated_At"),
         ("restarted", "Restarted"),
         ("restarted_at", "Restarted_At"),
         ("is_necessary", "Is_Necessary"),
         ("status", "Status"),
+        ("updated_at", "Updated_At")
     ])
 }
 


### PR DESCRIPTION
The `node_name` is global unique in ha deployment. So that the service can be fetched with `node_name`, no need for role and type any more.