### PR TITLE
Fix healthchecker

### DIFF
--- a/etc/ha_healthchecker/fix.py
+++ b/etc/ha_healthchecker/fix.py
@@ -105,17 +105,17 @@ def is_alarmed_timeout(svc_obj):
 def post_alarmed_if_possible(obj):
     if not obj.alarmed:
         zk_cli = get_zk_cli()
-        if 'node' in obj.__name__.lower():
+        if 'node' in obj.__class__.__name__.lower():
             zk_cli.update_node(obj.name, alarmed=True)
             LOG.info("%()s Node %(name)s updated with %(status)s "
                      "alarmed=True",
                      {'name': obj.name,
                       'role': obj.role})
             obj.alarmed = True
-        elif 'service' in obj.__name__.lower():
+        elif 'service' in obj.__class__.__name__.lower():
             local_node = get_local_node()
             updated_svc = zk_cli.update_service(
-                obj.name, local_node.role, local_node.type, alarmed=True)
+                obj.name, local_node.name, alarmed=True)
             LOG.info("Service %(name)s updated with alarmed=True",
                      {'name': obj.name})
             obj.alarmed = True

--- a/etc/ha_healthchecker/ha_healthchecker.service
+++ b/etc/ha_healthchecker/ha_healthchecker.service
@@ -2,4 +2,4 @@
 Description=HA Healthchecker
 
 [Service]
-ExecStart=/etc/openlab/ha_healthchecker/healthchecker.sh
+ExecStart=/etc/openlab/ha_healthchecker/ha_healthchecker.sh

--- a/etc/ha_healthchecker/refresh.py
+++ b/etc/ha_healthchecker/refresh.py
@@ -154,7 +154,7 @@ def is_service_abnormal(service_obj, node_obj):
                 kwargs['alarmed_at'] = None
                 service_obj.alarmed = False
                 service_obj.alarmed_at = None
-        zk_cli.update_service(service_obj.name, node_obj.role, node_obj.type,
+        zk_cli.update_service(service_obj.name, node_obj.name,
                               status=service_obj.status, **kwargs)
         LOG.info("Service %(name)s updated with %(status)s status.",
                  {'name': service_obj.name,
@@ -166,7 +166,7 @@ def post_restarted_if_possible(service_obj, node_obj):
     if not service_obj.restarted:
         zk_cli = get_zk_cli()
         updated_svc = zk_cli.update_service(
-            service_obj.name, node_obj.role, node_obj.type,
+            service_obj.name, node_obj.name,
             restarted=True, status='restarting')
         LOG.info("Service %(name)s updated with %(status)s status "
                  "and restarted=True",

--- a/openlabcmd/openlabcmd/service.py
+++ b/openlabcmd/openlabcmd/service.py
@@ -43,10 +43,12 @@ class ServiceStatus(object):
     UP = 'up'
     DOWN = 'down'
     RESTARTING = 'restarting'
+    ERROR = 'error'
 
     @property
     def all_status(self):
-        return [self.INITIALIZING, self.UP, self.DOWN, self.RESTARTING]
+        return [self.INITIALIZING, self.UP, self.DOWN, self.RESTARTING,
+                self.ERROR]
 
 
 class Service(object):

--- a/playbooks/ha_healthchecker.yaml
+++ b/playbooks/ha_healthchecker.yaml
@@ -38,7 +38,7 @@
 
     - name: install script dependency
       pip:
-        name: ['six', 'iso8601', 'requests', 'configparser', 'PyGithub', 'openlabcmd', 'logging']
+        name: ['six', 'iso8601', 'requests', 'configparser', 'PyGithub', 'openlabcmd']
         executable: pip3
 
     - name: config ha_healthchecker

--- a/playbooks/ha_healthchecker.yaml
+++ b/playbooks/ha_healthchecker.yaml
@@ -38,7 +38,7 @@
 
     - name: install script dependency
       pip:
-        name: ['six', 'iso8601', 'requests', 'configparser', 'PyGithub', 'openlabcmd']
+        name: ['six', 'iso8601', 'requests', 'PyGithub']
         executable: pip3
 
     - name: config ha_healthchecker


### PR DESCRIPTION
1. Add service error status in openlabcmd
2. Remove built-in libiary logging
3. Refacor to fit new zk API.
4. Fix some issues in healthchecker scripts.