### PR TITLE
Fix openlabcmd 

### DIFF
--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -186,6 +186,7 @@ class ZooKeeper(object):
             else:
                 if node_obj.status == node.NodeStatus.MAINTAINING:
                     node_obj.status = node.NodeStatus.UP
+                    node_obj.heartbeat = datetime.datetime.utcnow()
                 else:
                     raise exceptions.ClientError(
                         "The node must be in 'maintaining' status when trying "

--- a/playbooks/ha_openlabcmd_install.yaml
+++ b/playbooks/ha_openlabcmd_install.yaml
@@ -6,6 +6,7 @@
     - name: Install openlabcmd
       pip:
         name: openlabcmd
+        executable: pip3
 
     - name: Ensures openlabcmd config dir exists
       file: path=/etc/openlab state=directory


### PR DESCRIPTION
1. HA tools now are ruuning under py3 by default. Openlabcmd should
be under py3 as well.

2. When users set node from `mantained` to `up`, the heartbeat should
be refreshed as well.
