### PR TITLE
Disable statsd servier by default

### DIFF
--- a/etc/zuul/zuul.conf.j2
+++ b/etc/zuul/zuul.conf.j2
@@ -17,8 +17,8 @@ tenant_config = {{ zuul_file_main_yaml_dest }}
 log_config = /etc/zuul/scheduler-logging.conf
 state_dir = {{ zuul_user_home }}
 
-[statsd]
-server = {{ hostvars[inventory_hostname].ansible_host }}
+# [statsd]
+# server = {{ hostvars[inventory_hostname].ansible_host }}
 
 [executor]
 finger_port = 17979

--- a/inventory/openlab.yaml
+++ b/inventory/openlab.yaml
@@ -55,6 +55,8 @@ all:
       hosts: zuul01
     statsd:
       hosts: zuul01
+      vars:
+        statsd_service_statsd_state: stopped
     zookeeper:
       hosts: nodepool01
     mysql:

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -14,7 +14,10 @@
 ---
 - import_playbook: bastion.yaml
 - import_playbook: prerequisites.yaml
-- import_playbook: statsd.yaml
+# NOTE: Statsd sometimes consume much disk spaces and doesn't release them
+#       normally. Since it is not used by OpenLab at this moment, comment it
+#       out.
+#- import_playbook: statsd.yaml
 - import_playbook: gearman-apt.yaml
 - import_playbook: zookeeper.yaml
 - import_playbook: config-mysql.yaml


### PR DESCRIPTION
statsd is not used by openlab currently. Disable it now.