### PR TITLE
Add long_description_content_type

### DIFF
--- a/openlabcmd/setup.cfg
+++ b/openlabcmd/setup.cfg
@@ -3,6 +3,7 @@ name = openlabcmd
 summary = The command line tool for OpenLab
 description-file =
     README.md
+long_description_content_type = text/markdown
 author = OpenLab Team
 home-page = https://openlabtesting.org/
 classifier =


### PR DESCRIPTION
When release openlabcmd, Pypi need to know the README's format if not `rst`. Otherwise Pypi will return 400 error.