### PR TITLE
Move ha install step to the last

### DIFF
--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -31,9 +31,6 @@
 - import_playbook: zuul-merger.yaml
 - import_playbook: zuul-web.yaml
 - import_playbook: zuul-log-server.yaml
-- import_playbook: ha_log_cfg_sync.yaml
-- import_playbook: ha_openlabcmd_install.yaml
-- import_playbook: ha_healthchecker.yaml
 - import_playbook: apache.yaml
 - import_playbook: sync-config-files.yaml
   when: labsync_enabled|default(false)|bool
@@ -41,3 +38,6 @@
   when: labcheck_enabled|default(false)|bool
 - import_playbook: conf-new-slave.yaml
   when: config_new_slave|default(false)|bool
+- import_playbook: ha_log_cfg_sync.yaml
+- import_playbook: ha_openlabcmd_install.yaml
+- import_playbook: ha_healthchecker.yaml


### PR DESCRIPTION
HA health check service should be started after all other services installed.

Related-Bug: theopenlab/openlab#218