### PR TITLE
Fix alarmed status for node and support change switch_status operation.

### DIFF
--- a/etc/ha_healthchecker/ha_healthchecker.py.j2
+++ b/etc/ha_healthchecker/ha_healthchecker.py.j2
@@ -714,15 +714,18 @@ class Switcher(Base):
                 'start' in set(res) and
                 'end' in set(res))
 
-    def _do_switch(self):
+    def _do_switch(self, force_switch=False):
         if self.node.role == 'master':
             self._shut_down_all_services(self.node)
-            self.zk.update_node(self.node.name, role='slave', status='down',
-                                switch_status='end')
+            update_dict = {'role': 'slave', 'switch_status': 'end'}
+            if not force_switch:
+                update_dict['status'] = 'down'
+            self.zk.update_node(self.node.name, **update_dict)
             LOG.info("M/S switching: local node, %(role)s node %(name)s is "
                      "finishd from master to slave. And update it with "
-                     "role=slave and status=down.",
-                     {'role': self.node.role, 'name': self.node.name})
+                     "role=slave%(ext_msg)s.",
+                     {'role': self.node.role, 'name': self.node.name,
+                      'ext_msg': ' and status=down' if not force_switch else ''})
 
         elif self.node.role == 'slave':
             if self.node.type == 'zuul':
@@ -743,11 +746,21 @@ class Switcher(Base):
         return 'start' not in res
 
     def run(self):
+        is_force_swtich = False
+        # This is the normal case, once reach the switch condition we do the
+        # normal switch.
         if self._is_need_switch():
             if self._can_start_switch():
-                self._do_switch()
+                self._do_switch(force_switch=is_force_swtich)
+        # But if we found the current switch start are all start, and not reach
+        # the switch condition, that means the deploy manager setting the
+        # switch_status to start manually and want to do a S/W swtich.
+        else:
+            if self._can_start_switch():
+                is_force_swtich = True
+                self._do_switch(force_switch=is_force_swtich)
         if self._is_switching() and self.node.switch_status == 'start':
-            self._do_switch()
+            self._do_switch(force_switch=is_force_swtich)
 
         if self._is_end():
             self.zk.update_node(self.node.name, switch_status=None)

--- a/etc/ha_healthchecker/ha_healthchecker.py.j2
+++ b/etc/ha_healthchecker/ha_healthchecker.py.j2
@@ -547,7 +547,8 @@ class Switcher(Base):
         # switch preparation period, we fix the switch condition, so this time,
         # we didn't find a switching condition, we must set back the
         # switch_status to None.
-        if not need_switch and self.node.switch_status == 'start':
+        if (not need_switch and self.node.switch_status == 'start' and
+                not self._can_start_switch()):
             self.zk.update_node(self.node.name, switch_status=None)
             LOG.info("Global checking result: setting back switch_status "
                      "from %(status)s to None on %(role)s node %(name)s.",

--- a/etc/ha_healthchecker/ha_healthchecker.py.j2
+++ b/etc/ha_healthchecker/ha_healthchecker.py.j2
@@ -171,12 +171,35 @@ class Refresher(Base):
             self.zk.update_service(service_obj.name, node_obj.name,
                                    **update_dict)
 
+    def _need_fix_alarmed_status(self, node):
+        service_objs = self.zk.list_services(node_name_filter=node.name)
+        err_svcs = []
+        for service_obj in service_objs:
+            if service_obj.status == 'down':
+                err_svcs.append(service_obj)
+
+        need_fix = False
+        if len(err_svcs) == 0:
+            need_fix = True
+        else:
+            fix_res = []
+            for err_svc in err_svcs:
+                if (not err_svc.is_necessary and
+                        not self._is_alarmed_timeout(err_svc) and
+                        node.role == 'master'):
+                    fix_res.append(True)
+            if len(err_svcs) == len(fix_res):
+                need_fix = True
+
+        return need_fix and node.alarmed
+
     def _report_heart_beat(self, node_obj):
         hb = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
         update_dict = {'heartbeat': hb}
         if node_obj.status == 'initializing':
             update_dict['status'] = 'up'
-        if node_obj.alarmed and node_obj.role == 'slave':
+        if ((node_obj.alarmed and node_obj.role == 'slave') or
+                self._need_fix_alarmed_status(node_obj)):
             update_dict['alarmed'] = False
         self.zk.update_node(node_obj.name, **update_dict)
         LOG.debug("Report node %(name)s heartbeat %(hb)s",
@@ -518,6 +541,19 @@ class Switcher(Base):
                      {'status': 'end'.upper(),
                       'role': self.oppo_node.role,
                       'name': self.oppo_node.name})
+
+        # if we arrive here, that means the switch condition can not reach, but
+        # the swtich_status already be set with 'start', that means during the
+        # switch preparation period, we fix the switch condition, so this time,
+        # we didn't find a switching condition, we must set back the
+        # switch_status to None.
+        if not need_switch and self.node.switch_status == 'start':
+            self.zk.update_node(self.node.name, switch_status=None)
+            LOG.info("Global checking result: setting back switch_status "
+                     "from %(status)s to None on %(role)s node %(name)s.",
+                     {'status': 'start'.upper(),
+                      'role': self.node.role,
+                      'name': self.node.name})
         return need_switch
 
     def _run_systemctl_command(self, command, service):


### PR DESCRIPTION
For now, there is no way to set node alarmed back to None, this patch
adds a way to self fix the alarmed status.
1. local services are OK. Set back to None, if node alarmed is True.
2. if the err services are all unecessary services and alarmed is not
timeout, also the local node is master.

Also, this patch introduces a way to set back the internal
switch_status.

Secondery, This patch support operator force setting the switch_status to start to
do a S/W swtich manually.

Related-Bug: theopenlab/openlab#218