### PR TITLE
Refresh dns public ip

### DIFF
--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -334,6 +334,11 @@ class ZooKeeper(object):
         switch master-slave role by hand. Once health checker find that all
         nodes' switch status are `start`, it will start to switch cluster.
         """
+        configs = self.list_configuration()
+        self.update_configuration('dns_master_public_ip',
+                                  configs['dns_slave_public_ip'])
+        self.update_configuration('dns_slave_public_ip',
+                                  configs['dns_master_public_ip'])
         for node in self.list_nodes():
             self.update_node(node.name, switch_status='start')
 

--- a/playbooks/conf-new-slave.yaml
+++ b/playbooks/conf-new-slave.yaml
@@ -60,3 +60,14 @@
         section: "zookeeper"
         option: "hosts"
         value: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_host']) | join(', ') }}"
+
+- name: Run openlabcmd
+  become: yes
+  hosts: zuul-master
+  tasks:
+    - name: Run openlab ha config set cmd
+      shell: |
+        openlab ha config set dns_master_public_ip '{{ hostvars[groups["zuul-master"][0]].ansible_host }}'
+        openlab ha config set dns_slave_public_ip '{{ hostvars[groups["zuul-slave"][0]].ansible_host }}'
+      args:
+        executable: /bin/bash


### PR DESCRIPTION
When HA related action happen, the dns public ip stored in zk should be refreshed as well.

Related-Bug: theopenlab/openlab#218