### PR TITLE
Fix some HA bug

### DIFF
--- a/etc/ha_healthchecker/ha_healthchecker.py.j2
+++ b/etc/ha_healthchecker/ha_healthchecker.py.j2
@@ -205,11 +205,10 @@ class Refresher(Base):
                                          'status': 'down'.upper()})
 
     def run(self):
-        if self.node.status in ['maintaining', 'down']:
+        if self.node.status == 'maintaining':
             self.cfg_cache.LOG.debug(
-                'Node %(name)s status is %(status)s, Skipping refresh.',
-                {'name': self.node.name,
-                 'status': self.node.status.upper()})
+                'Node %(name)s status is MAINTAINING, Skipping refresh.',
+                {'name': self.node.name})
             return
         self._local_node_service_process(self.node)
         if self.oppo_node:
@@ -683,6 +682,10 @@ class Switcher(Base):
                     "Details: code-status %s\n         message: %s" % (
                         res.status_code, res.reason))
                 return
+        self.zk.update_configuration('dns_master_public_ip',
+                                     self.cfg_cache.dns_slave_public_ip)
+        self.zk.update_configuration('dns_slave_public_ip',
+                                     self.cfg_cache.dns_master_public_ip)
         self.cfg_cache.LOG.info("Finish update DNS entry.")
 
     def _can_start_switch(self):

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -23,7 +23,7 @@ CONFIGURATION_DICT = {
     'dns_status_domain': 'test-status.openlabtesting.org',
     'github_repo': None,
     'github_user_token': None,
-    'heartbeat_timeout_second': 150,
+    'heartbeat_timeout_second': 600,
     'logging_level': 'DEBUG',
     'logging_path': '/etc/openlab/ha_healthchecker/ha_healthchecker.log',
     'unnecessary_service_switch_timeout_hour': 48,
@@ -334,11 +334,6 @@ class ZooKeeper(object):
         switch master-slave role by hand. Once health checker find that all
         nodes' switch status are `start`, it will start to switch cluster.
         """
-        configs = self.list_configuration()
-        self.update_configuration('dns_master_public_ip',
-                                  configs['dns_slave_public_ip'])
-        self.update_configuration('dns_slave_public_ip',
-                                  configs['dns_master_public_ip'])
         for node in self.list_nodes():
             self.update_node(node.name, switch_status='start')
 

--- a/playbooks/conf-new-slave.yaml
+++ b/playbooks/conf-new-slave.yaml
@@ -78,7 +78,6 @@
   tasks:
     - name: Run openlab ha config set cmd
       shell: |
-        openlab ha config set dns_master_public_ip '{{ hostvars[groups["zuul-master"][0]].ansible_host }}'
         openlab ha config set dns_slave_public_ip '{{ hostvars[groups["zuul-slave"][0]].ansible_host }}'
       args:
         executable: /bin/bash


### PR DESCRIPTION
1. change `heartbeat_timeout_second` default value to 600 to make the HA switch check more reasonable.
2. When updating dns, the related config options should be updated as well.
3. When the node's status is down, healthchecker should works as refresher.

Related-Bug: theopenlab/openlab#218