### PR TITLE
Add openlab repo list cmd

### DIFF
--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -166,3 +166,21 @@ Mange the HA cluster configuration
     -h, --help            show this help message and exit
 
   ```
+
+
+### repo
+The management tool for the repos which enable the OpenLab.
+
+```
+usage: openlab repo list [-h] [--server SERVER] [--app-id APP_ID]
+                         [--app-key APP_KEY]
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --server SERVER    Specify base server url. Default is github.com
+  --app-id APP_ID    Specify the github APP ID, Default is 7102 (allinone:
+                     7102, OpenLab: 6778).
+  --app-key APP_KEY  Specify the app key file path. Default is
+                     /var/lib/zuul/openlab-app-key.pem
+```
+

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -10,6 +10,7 @@ from openlabcmd.plugins import base
 from openlabcmd import utils
 from openlabcmd.utils import _color
 from openlabcmd import zk
+from openlabcmd import repo
 
 
 class OpenLabCmd(object):
@@ -54,6 +55,28 @@ class OpenLabCmd(object):
                                help='Enable the no color mode.')
         cmd_check.add_argument('--recover', action='store_true',
                                help='Enable the auto recover mode.')
+
+    def _add_repo_cmd(self, parser):
+        # openlab repo list
+        cmd_repo = parser.add_parser(
+            'repo',
+            help='The repos which enable the OpenLab.')
+        cmd_repo_list_sub = cmd_repo.add_subparsers(title='repo',dest='repo')
+        cmd_repo_list = cmd_repo_list_sub.add_parser(
+            'list', help='List the repos which enable the OpenLab app.')
+
+        cmd_repo_list.set_defaults(func=self.repo_list)
+        cmd_repo_list.add_argument('--server', default='github.com',
+                                   help="Specify base server url. Default is "
+                                        "github.com")
+        cmd_repo_list.add_argument(
+            '--app-id', default='7102',
+            help="Specify the github APP ID, Default is 7102 (allinone: 7102,"
+                 " OpenLab: 6778).")
+        cmd_repo_list.add_argument(
+            '--app-key', default='/var/lib/zuul/openlab-app-key.pem',
+            help='Specify the app key file path. Default is '
+                 '/var/lib/zuul/openlab-app-key.pem')
 
     def _add_ha_node_cmd(self, parser):
         # openlab ha node
@@ -207,6 +230,7 @@ class OpenLabCmd(object):
 
         subparsers = parser.add_subparsers(title='commands',
                                            dest='command')
+        self._add_repo_cmd(subparsers)
         self._add_check_cmd(subparsers)
         self._add_ha_cmd(subparsers)
 
@@ -231,6 +255,14 @@ class OpenLabCmd(object):
     def _header_print(self, header):
         print(_color(header))
         print(_color("=" * 48))
+
+    def repo_list(self):
+        r = repo.Repo(self.args.server,
+                      self.args.app_id,
+                      self.args.app_key)
+        repos = r.list()
+        print(utils.format_output('repo', repos))
+        print("Total: %s" % len(repos))
 
     def check(self):
         utils.NOCOLOR = self.args.nocolor

--- a/openlabcmd/openlabcmd/repo.py
+++ b/openlabcmd/openlabcmd/repo.py
@@ -1,0 +1,34 @@
+from openlabcmd import exceptions
+
+
+class Repo(object):
+
+    def __init__(self, server, appid, appkey):
+        # NOTE(yikun): There are two reason we only allow this cmd is executed
+        # in zuul node:
+        # 1. The app installation interface has been completely supported by
+        # zuul github driver (but PyGithub is not supported yet), so we use
+        # it directly to avoid to build the duplicate wheels.
+        # 2. The app key which is usually only existed in Zuul node.
+        try:
+            from zuul.driver.github.githubconnection import GithubConnection
+            from zuul.driver.github import GithubDriver
+        except ImportError:
+            raise exceptions.ClientError(
+                "Error: 'openlab repo list' only can be used in Zuul node.")
+
+        driver = GithubDriver()
+        connection_config = {
+            'server': server,
+            'app_id': appid,
+            'app_key': appkey,
+        }
+        self.conn = GithubConnection(driver, 'github', connection_config)
+        self.conn._authenticateGithubAPI()
+        self.conn._prime_installation_map()
+
+    def list(self):
+        repos = [{"repo": x} for x in self.conn.installation_map]
+        # sort from aA to zZ
+        repos.sort(key=lambda x: x["repo"].lower())
+        return repos

--- a/openlabcmd/openlabcmd/utils.py
+++ b/openlabcmd/openlabcmd/utils.py
@@ -42,6 +42,9 @@ _headers_table_mapping = {
         ("is_necessary", "Is_Necessary"),
         ("status", "Status"),
         ("updated_at", "Updated_At")
+    ]),
+    'repo': OrderedDict([
+        ("repo", "Repo")
     ])
 }
 
@@ -57,10 +60,11 @@ def format_output(headers_table_name, objs):
         for obj in objs:
             values = []
             for k in headers_table:
-                if isinstance(getattr(obj, k), list):
-                    values.append(','.join(getattr(obj, k)))
+                val = obj.get(k) if isinstance(obj, dict) else getattr(obj, k)
+                if isinstance(val, list):
+                    values.append(','.join(val))
                 else:
-                    values.append(getattr(obj, k))
+                    values.append(val)
             t.add_row(values)
     return t
 


### PR DESCRIPTION
In order to query the list of repos which enable the openlab app or
allinone app, we propose to add a new cmd to support it.

```
usage: openlab repo list [-h] [--server SERVER] [--app-id APP_ID]
                          [--app-key APP_KEY]

optional arguments:
  -h, --help         show this help message and exit
  --server SERVER    Specify base server url. Default is github.com
  --app-id APP_ID    Specify the github APP ID, Default is 7102
                     (allinone: 7102, OpenLab: 6778).
  --app-key APP_KEY  Specify the app key file path. Default is
                     /var/lib/zuul/openlab-app-key.pem
```

closed: theopenlab/openlab#272