### PR TITLE
Add new_zookeeper deployment type

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -14,8 +14,8 @@ def add_cli_args():
                         help='OpenLab deployment type',
                         )
     parser.add_argument('--action',
-                        choices=["deploy", "new-slave", "switch-role",
-                                 "show-graph", "show-ip"],
+                        choices=["deploy", "new-slave", "new-zookeeper",
+                                 "switch-role", "show-graph", "show-ip"],
                         default="deploy",
                         help="The action that labkeeper supports. Default "
                              "value is 'deploy'.\n"
@@ -68,6 +68,9 @@ def main():
     elif parsed_args.action == 'new-slave':
         cmd = ['ansible-playbook', '-i', 'inventory/inventory.py',
                'playbooks/site.yaml', '-l', '*-slave']
+    elif parsed_args.action == 'new-zookeeper':
+        cmd = ['ansible-playbook', '-i', 'inventory/inventory.py',
+               'playbooks/site.yaml', '-l', 'zk-03']
     elif parsed_args.action == 'switch-role':
         os.environ['OL_SWITCH_MASTER_SLAVE'] = True
         cmd = ['ansible-playbook', '-i', 'inventory/inventory.py',
@@ -101,6 +104,9 @@ def main():
     if parsed_args.action == 'new-slave':
         subprocess.call(['ansible-playbook', '-i', 'inventory/inventory.py',
                          'playbooks/conf-new-slave.yaml'])
+    elif parsed_args.action == 'new-zookeeper':
+        subprocess.call(['ansible-playbook', '-i', 'inventory/inventory.py',
+                         'playbooks/conf-new-zookeeper.yaml'])
 
 
 if __name__ == '__main__':

--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -38,6 +38,17 @@ OpenLab HA cluster management commands.
 CRUD for node
 
 * openlab ha node list
+  ```
+  usage: openlab ha node list [-h] [--type {nodepool,zuul,zookeeper}]
+                                 [--role {master,slave,zookeeper}]
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --type {nodepool,zuul,zookeeper}
+                          Filter the services with the specified node type.
+    --role {master,slave,zookeeper}
+                          Filter the services with the specified node role.
+  ```
 * openlab ha node get
   ```
   usage: openlab ha node get [-h] name

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -64,6 +64,14 @@ class OpenLabCmd(object):
         cmd_ha_node_list = cmd_ha_node_subparsers.add_parser(
             'list', help='List all nodes.')
         cmd_ha_node_list.set_defaults(func=self.ha_node_list)
+        cmd_ha_node_list.add_argument(
+            '--type', action='append',
+            choices=['nodepool', 'zuul', 'zookeeper'],
+            help='Filter the services with the specified node type.')
+        cmd_ha_node_list.add_argument(
+            '--role', action='append',
+            choices=['master', 'slave', 'zookeeper'],
+            help='Filter the services with the specified node role.')
         # openlab ha node get
         cmd_ha_node_get = cmd_ha_node_subparsers.add_parser(
             'get', help='Get a node.')
@@ -271,11 +279,15 @@ class OpenLabCmd(object):
 
     @_zk_wrapper
     def ha_node_list(self):
-        result = self.zk.list_nodes()
+        result = self.zk.list_nodes(node_role_filter=self.args.role,
+                                    node_type_filter=self.args.type)
         if self.args.format == 'pretty':
             print(utils.format_output('node', result))
         else:
-            print(result.to_dict())
+            dict_result = []
+            for node in result:
+                dict_result.append(node.to_dict())
+            print(dict_result)
 
     @_zk_wrapper
     def ha_node_get(self):

--- a/playbooks/conf-new-zookeeper.yaml
+++ b/playbooks/conf-new-zookeeper.yaml
@@ -1,0 +1,69 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+---
+
+- name: Config zookeeper for HA deployment
+  become: yes
+  hosts: zk-master, zk-slave, zk-03
+  tasks:
+    - name: Config zookeeper myid
+      shell: echo {{ zk_myid }} > /var/lib/zookeeper/myid
+      args:
+        executable: /bin/bash
+
+    - name: Config zookeeper cluster
+      ini_file:
+        path: /etc/zookeeper/conf/zoo.cfg
+        option: "server.{{ hostvars[item].zk_myid }}"
+        section: null
+        value: "{{ hostvars[item].ansible_host }}:2888:3888"
+      with_items: "{{ groups['zookeeper'] }}"
+
+    - name: Restart zookeeper services
+      service: name=zookeeper state=restarted
+
+- name: Update zookeeper config for zuul
+  become: yes
+  hosts: nodepool-builder-master, nodepool-builder-slave
+  tasks:
+    - name: modify zuul.conf to use new zookeeper servers
+      shell: |
+        sed -i "/^zookeeper-servers:$/{N;N;N;N;N;N;s/.*/zookeeper-servers:\n  \
+        - host: \'{{ hostvars[groups["zookeeper"][0]].ansible_host }}\'\n    port: 2181\n  \
+        - host: \'{{ hostvars[groups["zookeeper"][1]].ansible_host }}\'\n    port: 2181\n  \
+        - host: \'{{ hostvars[groups["zookeeper"][2]].ansible_host }}\'\n    port: 2181/}" \
+        /etc/nodepool/nodepool.yaml
+      args:
+        executable: /bin/bash
+
+- name: Update zookeeper config for zuul
+  become: yes
+  hosts: zuul-scheduler-master, zuul-scheduler-slave
+  tasks:
+    - name: modify zuul.conf to use new zookeeper servers
+      ini_file:
+        path: /etc/zuul/zuul.conf
+        section: "zookeeper"
+        option: "hosts"
+        value: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_host']) | join(', ') }}"
+
+- name: Update zookeeper config for openlabcmd
+  become: yes
+  hosts: nodepool-master, nodepool-slave, zuul-master, zuul-slave, zk03
+  tasks:
+    - name: modify openlab.conf to use new zookeeper servers
+      ini_file:
+        path: /etc/openlab/openlab.conf
+        section: "ha"
+        option: "zookeeper_hosts"
+        value: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_host']) | join(', ') }}"

--- a/playbooks/ha_openlabcmd_install.yaml
+++ b/playbooks/ha_openlabcmd_install.yaml
@@ -18,6 +18,10 @@
 
     - name: Init HA node
       shell: |
+        for node in `openlab ha node list --role '{{ node_role }}' --type  '{{ node_type }}' | awk '{print $2}' | grep -`; do
+          openlab ha node delete $node
+        done
+
         openlab ha node init --role '{{ node_role }}' --type  '{{ node_type }}' \
         --ip '{{ hostvars[inventory_hostname]['ansible_host'] }}' $(hostname)
       args:


### PR DESCRIPTION
1. Add `new-zookeeper` action for deploy type.
2. Fixed a openlabcmd bug that hearbeat is not string when saving to zookeeper.
3. Add `type` and `role` filter for `node list`
4. When install openlabcmd, clear the old node info first.

Related-Bug: theopenlab/openlab#218