### PR TITLE
Disable rsyncd during switch role

### DIFF
--- a/playbooks/ha_log_cfg_sync.yaml
+++ b/playbooks/ha_log_cfg_sync.yaml
@@ -70,7 +70,7 @@
         set -xe
         systemctl disable rsyncd.service || true
       args:
-      executable: /bin/bash
+        executable: /bin/bash
 
 - name: Setup crontab job for sync zuul jobs logs files
   hosts: logserver-master

--- a/playbooks/ha_log_cfg_sync.yaml
+++ b/playbooks/ha_log_cfg_sync.yaml
@@ -65,6 +65,13 @@
         content: "{{ rsync_password }}"
         mode: 0600
 
+    - name: Teardown original slave rsyncd(when slave master switched)
+      shell: |
+        set -xe
+        systemctl disable rsyncd.service || true
+      args:
+      executable: /bin/bash
+
 - name: Setup crontab job for sync zuul jobs logs files
   hosts: logserver-master
   become: yes

--- a/playbooks/switch_role.yaml
+++ b/playbooks/switch_role.yaml
@@ -10,14 +10,3 @@
         openlab ha cluster switch
       args:
         executable: /bin/bash
-
-- name: Teardown original slave rsyncd
-  become: yes
-  hosts: logserver-master, zuul-scheduler-master, nodepool-launcher-master
-  tasks:
-    - name: Disable rsyncd on ori slave
-      shell: |
-        set -xe
-        systemctl disable rsyncd.service
-      args:
-      executable: /bin/bash

--- a/playbooks/switch_role.yaml
+++ b/playbooks/switch_role.yaml
@@ -10,3 +10,14 @@
         openlab ha cluster switch
       args:
         executable: /bin/bash
+
+- name: Teardown original slave rsyncd
+  become: yes
+  hosts: logserver-master, zuul-scheduler-master, nodepool-launcher-master
+  tasks:
+    - name: Disable rsyncd on ori slave
+      shell: |
+        set -xe
+        systemctl disable rsyncd.service
+      args:
+      executable: /bin/bash


### PR DESCRIPTION
For rsync,
We need to disable the rsyncd service on ori slave nodes.

Related-Bug: theopenlab/openlab#218