### PR TITLE
openlabcmd python3 only

### DIFF
--- a/openlabcmd/setup.cfg
+++ b/openlabcmd/setup.cfg
@@ -6,14 +6,13 @@ description-file =
 long_description_content_type = text/markdown
 author = OpenLab Team
 home-page = https://openlabtesting.org/
+python-requires = >=3.5
 classifier =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
 


### PR DESCRIPTION
Since the main service like zuul or nodepool is python3 only and py2 is already deprecated, openlabcmd should use py3 as well.

Remove py2 support.

Related-Bug: theopenlab/openlab#272