### PR TITLE
Add cirros-0.4.0/cirros-0.3.5 check

### DIFF
--- a/openlabcmd/openlabcmd/plugins/jobs/image.py
+++ b/openlabcmd/openlabcmd/plugins/jobs/image.py
@@ -1,6 +1,7 @@
 import subprocess
 
 from openlabcmd.plugins.base import Plugin
+from openlabcmd.plugins.recover import Recover
 
 
 class ImagePlugin(Plugin):
@@ -15,6 +16,9 @@ class ImagePlugin(Plugin):
         image_check = 'openstack --os-cloud %s image list ' \
                       '-c "Name" -c "Status" -f value | grep cirros' % self.cloud
         res = subprocess.getoutput(image_check)
-        if "cirros" not in res:
+        if "cirros-0.3.5" not in res:
             self.failed = True
-            self.reasons.append("- Image: cirros image not found.")
+            self.reasons.append(Recover.IMAGE_CIRROS_035)
+        if "cirros-0.4.0" not in res:
+            self.failed = True
+            self.reasons.append(Recover.IMAGE_CIRROS_040)

--- a/openlabcmd/openlabcmd/plugins/recover.py
+++ b/openlabcmd/openlabcmd/plugins/recover.py
@@ -9,6 +9,8 @@ class Recover(Enum):
     NETWORK = 5
     NETWORK_SUBNET = 6
     NETWORK_SUBNET_CIDR = 7
+    IMAGE_CIRROS_035 = 8
+    IMAGE_CIRROS_040 = 9
 
 
 RECOVER_MAPS = {
@@ -44,5 +46,19 @@ RECOVER_MAPS = {
         "recover": "openstack --os-cloud %s subnet create openlab-subnet "
                    "--network openlab-net --subnet-range=192.168.199.0/24",
         "reason": "- Subnet cidr: 192.168.199.0/24 is not found.",
+    },
+    Recover.CIRROS_035: {
+        "recover": "curl -O http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img;"
+                   "openstack --os-cloud %s image create --file ./cirros-0.3.5-x86_64-disk.img "
+                   "--min-disk 1 --container-format bare --disk-format raw "
+                   "cirros-0.3.5-x86_64-disk -f value -c id",
+        "reason": "- Image: cirros-0.3.5 image not found.",
+    },
+    Recover.CIRROS_040: {
+        "recover": "curl -O http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img;"
+                   "openstack --os-cloud %s image create --file ./cirros-0.4.0-x86_64-disk.img "
+                   "--min-disk 1 --container-format bare --disk-format raw "
+                   "cirros-0.4.0-x86_64-disk -f value -c id",
+        "reason": "- Image: cirros-0.4.0 image not found.",
     },
 }


### PR DESCRIPTION
The cirros-0.4.0/0.3.5 are used by job, we enable the preparation
of these images is good for speeding up of job.

Part of https://github.com/theopenlab/openlab/issues/232