### PR TITLE
Correct the openstack git repo url in zuul.conf

### DIFF
--- a/etc/zuul/zuul.conf.j2
+++ b/etc/zuul/zuul.conf.j2
@@ -62,7 +62,7 @@ verify_ssl=false
 
 [connection openstack-git]
 driver=git
-baseurl=https://git.openstack.org/
+baseurl=https://opendev.org/
 
 [connection mysql]
 driver=sql


### PR DESCRIPTION
The OpenStack official repo has been moved to `opendev.org`, we should also follow it.