### PR TITLE
Fix the cron PATH in labcheck job

### DIFF
--- a/labcheck/lab_check_report.sh
+++ b/labcheck/lab_check_report.sh
@@ -2,6 +2,9 @@ github_token=$1
 
 set -e
 
+# the default path of cron is /usr/bin:/bin, add hub/openlab path to PATH
+export PATH=/usr/local/bin:$PATH
+
 if [ ! -d ~/labcheck/ ];then
     mkdir ~/labcheck
 fi
@@ -17,13 +20,11 @@ issue_header="[Labcheck] "`date +%Y%m%d%H%M`" OpenLab Environment Check Failed"
 issue_content="Check report as below:\n\`\`\`"
 echo -e $issue_header"\n\n"$issue_content > ~/labcheck/labcheck.issue
 
-openlab check --nocolor >> ~/labcheck/labcheck.issue
-retval=$?
-
-echo -e "\`\`\`\n\ncc: @theopenlab/ops">> ~/labcheck/labcheck.issue
-
-if [ $retval -ne 0 ]; then
+if ! openlab check --nocolor >> ~/labcheck/labcheck.issue; then
+    echo -e "\`\`\`\n\ncc: @theopenlab/ops">> ~/labcheck/labcheck.issue
     echo "[Labcheck] Check failed, report to openlab issue."
     export GITHUB_TOKEN=${github_token}
     hub issue create -F ~/labcheck/labcheck.issue
 fi
+
+echo `date +%Y-%m-%d-%H:%M`" [Labcheck] Labcheck completed!"


### PR DESCRIPTION
Cron jobs run in very minimal environment, the regular shell
setup never happens, so `/usr/local/bin` is not in the $PATH.

This patch add `/usr/local/bin` to PATH, which would be used
by `hub` and `openlab` cmd.

related: https://github.com/theopenlab/openlab/issues/232