### PR TITLE
Correct the openstack git repo and openstack-infra

### DIFF
--- a/etc/nodepool/repos.yaml
+++ b/etc/nodepool/repos.yaml
@@ -1,7 +1,7 @@
-- project: openstack-infra/project-config
-- project: openstack-dev/devstack
-- project: openstack-infra/devstack-gate
-- project: openstack-infra/tripleo-ci
+- project: openstack/project-config
+- project: openstack/devstack
+- project: openstack/devstack-gate
+- project: openstack/tripleo-ci
 - project: openstack/ceilometer
 - project: openstack/ceilometermiddleware
 - project: openstack/cinder

--- a/etc/zuul/allinone-main.yaml
+++ b/etc/zuul/allinone-main.yaml
@@ -43,4 +43,4 @@
           - include: []
             projects:
               - openstack/openstacksdk
-              - openstack-infra/shade
+              - openstack/shade

--- a/etc/zuul/openlab-main.yaml
+++ b/etc/zuul/openlab-main.yaml
@@ -78,4 +78,4 @@
           - include: []
             projects:
               - openstack/openstacksdk
-              - openstack-infra/shade
+              - openstack/shade

--- a/playbooks/nodepool-builder.yaml
+++ b/playbooks/nodepool-builder.yaml
@@ -37,7 +37,7 @@
 
     - name: Clone project-config
       git:
-        repo: 'https://github.com/openstack-infra/project-config.git'
+        repo: 'https://github.com/openstack/project-config.git'
         dest: /tmp/project-config
 
     - name: Copy elements from project-config into place

--- a/playbooks/upgrade-zuul.yaml
+++ b/playbooks/upgrade-zuul.yaml
@@ -63,7 +63,7 @@
         # npm pack
         # npm run  build:dist
       args:
-        chdir: '{{ ansible_user_dir }}/src/git.openstack.org/openstack-infra/zuul'
+        chdir: '{{ ansible_user_dir }}/src/opendev.org/openstack-infra/zuul'
         executable: /bin/bash
 
     - name: Restart zuul services


### PR DESCRIPTION
1. The OpenStack official repo has been moved to opendev.org,
we should also follow it.
2. some openstack-infra repos has been migrated to openstack.

Closes: theopenlab/openlab#284