### PR TITLE
Add allow_switch option

### DIFF
--- a/etc/ha_healthchecker/ha_healthchecker.py.j2
+++ b/etc/ha_healthchecker/ha_healthchecker.py.j2
@@ -750,6 +750,9 @@ class Switcher(Base):
         return True
 
     def run(self):
+        if not self.cfg_cache.allow_switch:
+            return
+
         if self.node.type == 'zookeeper':
             # zookeeper node don't need master/slave switch
             return

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -402,7 +402,10 @@ class OpenLabCmd(object):
 
     @_zk_wrapper
     def ha_config_update(self):
-        self.zk.update_configuration(self.args.name, self.args.value)
+        value = self.args.value
+        if self.args.name in ['allow_switch']:
+            value = self._str2bool(value)
+        self.zk.update_configuration(self.args.name, value)
 
     def run(self):
         # no arguments, print help messaging, then exit with error(1)

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -14,6 +14,7 @@ from openlabcmd import service
 
 
 CONFIGURATION_DICT = {
+    'allow_switch': False,
     'dns_log_domain': 'test-logs.openlabtesting.org',
     'dns_master_public_ip': None,
     'dns_provider_account': None,


### PR DESCRIPTION
Add a new option `allow_switch` to control HA switch action.
Default is False.

Related-Bug: theopenlab/openlab#218