### PR TITLE
Force to enable systemd services after installation ha success

### DIFF
--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -20,7 +20,6 @@
       shell: |
         set -xe
         systemctl enable nodepool-launcher.service || true
-        systemctl enable nodepool-launcher.service || true
         systemctl enable nodepool-builder.service || true
         systemctl enable zookeeper.service || true
       args:

--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -22,6 +22,7 @@
         systemctl enable nodepool-launcher.service || true
         systemctl enable nodepool-builder.service || true
         systemctl enable zookeeper.service || true
+        systemctl enable apache2.service || true
       args:
         executable: /bin/bash
 

--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -38,6 +38,8 @@
         systemctl enable zuul-web.service || true
         systemctl enable zuul-merger.service || true
         systemctl enable zuul-fingergw.service || true
+        systemctl enable mariadb.service || true
+        systemctl enable gearman-job-server.service || true
       args:
         executable: /bin/bash
 

--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -1,0 +1,53 @@
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+---
+- name: Install nodepool master node
+  become: yes
+  hosts: nodepool01
+  tasks:
+    - name: Force to enable nodepool services
+      shell: |
+        set -xe
+        systemctl enable nodepool-launcher.service || true
+        systemctl enable nodepool-launcher.service || true
+        systemctl enable nodepool-builder.service || true
+        systemctl enable zookeeper.service || true
+      args:
+        executable: /bin/bash
+
+- name: Install zuul master node
+  become: yes
+  hosts: zuul01
+  tasks:
+    - name: Force to enable zuul services
+      shell: |
+        set -xe
+        systemctl enable zuul-scheduler.service || true
+        systemctl enable zuul-executor.service || true
+        systemctl enable zuul-web.service || true
+        systemctl enable zuul-merger.service || true
+        systemctl enable zuul-fingergw.service || true
+      args:
+        executable: /bin/bash
+
+- name: Install zookeeper node
+  become: yes
+  hosts: zk03
+  tasks:
+    - name: Force to enable nodepool services
+      shell: |
+        set -xe
+        systemctl enable zookeeper.service || true
+      args:
+        executable: /bin/bash

--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -22,7 +22,6 @@
         systemctl enable nodepool-launcher.service || true
         systemctl enable nodepool-builder.service || true
         systemctl enable zookeeper.service || true
-        systemctl enable apache2.service || true
       args:
         executable: /bin/bash
 
@@ -40,6 +39,7 @@
         systemctl enable zuul-fingergw.service || true
         systemctl enable mariadb.service || true
         systemctl enable gearman-job-server.service || true
+        systemctl enable apache2.service || true
       args:
         executable: /bin/bash
 

--- a/playbooks/force-to-enable-services.yaml
+++ b/playbooks/force-to-enable-services.yaml
@@ -12,9 +12,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 ---
-- name: Install nodepool master node
+- name: Enable services on nodepool master node
   become: yes
-  hosts: nodepool01
+  hosts: nodepool-master
   tasks:
     - name: Force to enable nodepool services
       shell: |
@@ -25,9 +25,9 @@
       args:
         executable: /bin/bash
 
-- name: Install zuul master node
+- name: Enable services on zuul master node
   become: yes
-  hosts: zuul01
+  hosts: zuul-master
   tasks:
     - name: Force to enable zuul services
       shell: |
@@ -43,9 +43,9 @@
       args:
         executable: /bin/bash
 
-- name: Install zookeeper node
+- name: Enable service on zookeeper node
   become: yes
-  hosts: zk03
+  hosts: zk-03
   tasks:
     - name: Force to enable nodepool services
       shell: |

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -36,7 +36,7 @@
   when: labsync_enabled|default(false)|bool
 - import_playbook: check-nodepool-periodic.yaml
   when: labcheck_enabled|default(false)|bool
-  - import_playbook: force-to-enable-services.yaml
+- import_playbook: force-to-enable-services.yaml
 - import_playbook: ha_mysql_configure.yaml
 - import_playbook: ha_log_cfg_sync.yaml
 - import_playbook: ha_openlabcmd_install.yaml

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -40,3 +40,4 @@
 - import_playbook: ha_log_cfg_sync.yaml
 - import_playbook: ha_openlabcmd_install.yaml
 - import_playbook: ha_healthchecker.yaml
+- import_playbook: force-to-enable-services.yaml

--- a/playbooks/site.yaml
+++ b/playbooks/site.yaml
@@ -36,8 +36,8 @@
   when: labsync_enabled|default(false)|bool
 - import_playbook: check-nodepool-periodic.yaml
   when: labcheck_enabled|default(false)|bool
+  - import_playbook: force-to-enable-services.yaml
 - import_playbook: ha_mysql_configure.yaml
 - import_playbook: ha_log_cfg_sync.yaml
 - import_playbook: ha_openlabcmd_install.yaml
 - import_playbook: ha_healthchecker.yaml
-- import_playbook: force-to-enable-services.yaml


### PR DESCRIPTION
We found the zuul node won't startup automatically after reboot.
So we need to enable the all services into sytermd autostartup process
after installation ha.

Related-Bug: theopenlab/openlab#218