### PR TITLE
Remove keep-jobdir

### DIFF
--- a/playbooks/templates/zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
+++ b/playbooks/templates/zuul/etc/systemd/system/zuul-executor.service.d/override.conf.j2
@@ -5,4 +5,4 @@
 Group={{ zuul_user_group }}
 User={{ zuul_user_name }}
 ExecStart=
-ExecStart=/usr/local/bin/zuul-executor -d --keep-jobdir
+ExecStart=/usr/local/bin/zuul-executor -d


### PR DESCRIPTION
zuul-executor costs much disk space if keep-jobdir is open. Remove it now.