### PR TITLE
Add --delete for log rsync

### DIFF
--- a/playbooks/ha_log_cfg_sync.yaml
+++ b/playbooks/ha_log_cfg_sync.yaml
@@ -81,7 +81,7 @@
         dest: /etc/rsync/cron_sync_zuul_jobs_log.sh
         content: |
           #/bin/bash
-          rsync -auvrtzopgP --progress --password-file=/etc/rsync/rsync_client.pwd /srv/static/logs/ \
+          rsync -auvrtzopgP --progress --delete  --password-file=/etc/rsync/rsync_client.pwd /srv/static/logs/ \
           root@"{{ hostvars[groups['logserver-slave'][0]].ansible_host }}"::openlab_logserver
         mode: 0755
 


### PR DESCRIPTION
Once the logs on master is cleaned up, the related logs on slave should be cleaned as well. Otherwise the logs on slave will be much and much.