### PR TITLE
Add "openlab hint" cmd

### DIFF
--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -184,3 +184,13 @@ optional arguments:
                      /var/lib/zuul/openlab-app-key.pem
 ```
 
+### hint
+The help tool to print hints info.
+
+```
+usage: openlab hint [-h] [--type TYPE]
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --type TYPE  Specify a hint type, like 'resource', 'redundant'.
+```

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -11,6 +11,7 @@ from openlabcmd import utils
 from openlabcmd.utils import _color
 from openlabcmd import zk
 from openlabcmd import repo
+from openlabcmd import hint
 
 
 class OpenLabCmd(object):
@@ -55,6 +56,16 @@ class OpenLabCmd(object):
                                help='Enable the no color mode.')
         cmd_check.add_argument('--recover', action='store_true',
                                help='Enable the auto recover mode.')
+
+    def _add_hint_cmd(self, parser):
+        # openlab hint
+        cmd_hint = parser.add_parser(
+            'hint',
+            help='Print hint info.')
+        cmd_hint.set_defaults(func=self.hint)
+        cmd_hint.add_argument('--type', default='all',
+                              help="Specify a hint type, "
+                                   "like 'resource', 'redundant'.")
 
     def _add_repo_cmd(self, parser):
         # openlab repo list
@@ -230,6 +241,7 @@ class OpenLabCmd(object):
 
         subparsers = parser.add_subparsers(title='commands',
                                            dest='command')
+        self._add_hint_cmd(subparsers)
         self._add_repo_cmd(subparsers)
         self._add_check_cmd(subparsers)
         self._add_ha_cmd(subparsers)
@@ -255,6 +267,10 @@ class OpenLabCmd(object):
     def _header_print(self, header):
         print(_color(header))
         print(_color("=" * 48))
+
+    def hint(self):
+        h = hint.Hint(self.args.type)
+        h.print_hints()
 
     def repo_list(self):
         r = repo.Repo(self.args.server,

--- a/openlabcmd/openlabcmd/hint.py
+++ b/openlabcmd/openlabcmd/hint.py
@@ -1,0 +1,41 @@
+from openlabcmd import exceptions
+
+
+HINTS = {
+    "resource": [
+        "export CLOUD=vexxhost",
+        "openstack --os-cloud $CLOUD router list -f value -c Name | grep openlab",
+        "openstack --os-cloud $CLOUD subnet list -f value -c Name | grep openlab",
+        "openstack --os-cloud $CLOUD network list -f value -c Name | grep openlab",
+        "openstack --os-cloud $CLOUD keypair list -f value -c Name | grep openlab",
+        "openstack --os-cloud $CLOUD server list -f value -c Name | grep openlab"
+    ],
+    "redundant": [
+        "export CLOUD=vexxhost",
+        "echo $CLOUD':'",
+        "nodepool image-list | grep $CLOUD | awk -F'|' '{print $6}' | sed 's/ //g' > file1",
+        "openstack --os-cloud $CLOUD image list -f value -c Name | grep openlab-ubuntu > file2",
+        "sort file1 file2 | uniq -u",
+        "rm file1 file2"
+    ]
+}
+
+
+class Hint(object):
+
+    def __init__(self, htype):
+        self.hints = HINTS
+        self.htype = htype
+
+    def print_hints(self):
+        if self.htype == 'all':
+            for h in HINTS:
+                print("\n- Hint of %s:" % h)
+                for hint in HINTS.get(h):
+                    print(hint)
+        elif self.htype in HINTS:
+            print("\n- Hint of %s:" % self.htype)
+            for hint in HINTS.get(self.htype):
+                print(hint)
+        else:
+            raise exceptions.ClientError("No hints founded.")


### PR DESCRIPTION
This patch add a hint cmd to get the hints info.

usage: openlab hint [-h] [--type TYPE]

optional arguments:
  -h, --help   show this help message and exit
  --type TYPE  Specify a hint type, like 'resource', 'redundant'.

close: https://github.com/theopenlab/openlab/issues/232