### PR TITLE
add HA sg repair

### DIFF
--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -143,13 +143,13 @@ Manage the HA cluster action or check existing HA cluster deployment.
     -h, --help            show this help message and exit
   ```
 
-* openlab ha cluster check
+* openlab ha cluster repair
   '''
-  usage: openlab ha cluster check [-h] --security-group [--dry-run]
+  usage: openlab ha cluster repair [-h] --security-group [--dry-run]
 
   optional arguments:
     -h, --help        show this help message and exit
-    --security-group  Check the Security Group of HA deployment.
+    --security-group  Repair the Security Group of HA deployment.
     --dry-run         Only report the check list of HA deployment, not try to
                       fix if there is a check error.
 

--- a/openlabcmd/README.md
+++ b/openlabcmd/README.md
@@ -133,7 +133,7 @@ Get or list the service running in cluster.
 
 #### cluster
 
-Manage the HA cluster action.
+Manage the HA cluster action or check existing HA cluster deployment.
 
 * openlab ha cluster switch
   ```
@@ -142,6 +142,18 @@ Manage the HA cluster action.
   optional arguments:
     -h, --help            show this help message and exit
   ```
+
+* openlab ha cluster check
+  '''
+  usage: openlab ha cluster check [-h] --security-group [--dry-run]
+
+  optional arguments:
+    -h, --help        show this help message and exit
+    --security-group  Check the Security Group of HA deployment.
+    --dry-run         Only report the check list of HA deployment, not try to
+                      fix if there is a check error.
+
+  '''
 
 #### config
 

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -187,6 +187,14 @@ class OpenLabCmd(object):
             'switch', help='Switch Master and Slave role.')
         cmd_ha_service_get.set_defaults(func=self.ha_cluster_switch)
 
+        # openlab ha cluster check
+        cmd_ha_cluster_check = cmd_ha_cluster_subparsers.add_parser(
+            'check', help='HA deployment check.')
+        cmd_ha_cluster_check.set_defaults(func=self.ha_cluster_check)
+        cmd_ha_cluster_check.add_argument(
+            '--dry-run', help='Check the Security Group of HA deployment.',
+            action='store_true')
+
     def _add_ha_config_cmd(self, parser):
         # openlab ha cluster
         cmd_ha_config = parser.add_parser('config',
@@ -391,6 +399,14 @@ class OpenLabCmd(object):
             print("Switch success")
         except exceptions.OpenLabCmdError:
             print("Switch failed")
+    
+    @_zk_wrapper
+    def ha_cluster_check(self):
+        try:
+            self.zk.check_deployment(is_dry_run=self.args.dry_run)
+            print("Check success")
+        except exceptions.OpenLabCmdError:
+            print("Check failed")
 
     @_zk_wrapper
     def ha_config_list(self):

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -187,17 +187,17 @@ class OpenLabCmd(object):
             'switch', help='Switch Master and Slave role.')
         cmd_ha_service_get.set_defaults(func=self.ha_cluster_switch)
 
-        # openlab ha cluster check
+        # openlab ha cluster repair
         cmd_ha_cluster_check = cmd_ha_cluster_subparsers.add_parser(
-            'check', help='HA deployment check.')
+            'repair', help='HA deployment check and repair.')
         cmd_ha_cluster_check.set_defaults(func=self.ha_cluster_check)
         cmd_ha_cluster_check.add_argument(
             '--security-group',
-            help='Check the Security Group of HA deployment.',
+            help='Repair the Security Group of HA deployment.',
             action='store_true', required=True)
         cmd_ha_cluster_check.add_argument(
             '--dry-run', help='Only report the check list of HA deployment,'
-                              ' not try to fix if there is a check error.',
+                              ' not try to repair if there is a check error.',
             action='store_true')
 
     def _add_ha_config_cmd(self, parser):

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -192,7 +192,12 @@ class OpenLabCmd(object):
             'check', help='HA deployment check.')
         cmd_ha_cluster_check.set_defaults(func=self.ha_cluster_check)
         cmd_ha_cluster_check.add_argument(
-            '--dry-run', help='Check the Security Group of HA deployment.',
+            '--security-group',
+            help='Check the Security Group of HA deployment.',
+            action='store_true', required=True)
+        cmd_ha_cluster_check.add_argument(
+            '--dry-run', help='Only report the check list of HA deployment,'
+                              ' not try to fix if there is a check error.',
             action='store_true')
 
     def _add_ha_config_cmd(self, parser):
@@ -402,11 +407,13 @@ class OpenLabCmd(object):
     
     @_zk_wrapper
     def ha_cluster_check(self):
-        try:
-            self.zk.check_deployment(is_dry_run=self.args.dry_run)
-            print("Check success")
-        except exceptions.OpenLabCmdError:
-            print("Check failed")
+        # TODO(bz) This check may support other function
+        if self.args.security_group:
+            try:
+                self.zk.check_deployment_sg(is_dry_run=self.args.dry_run)
+                print("Check success")
+            except exceptions.OpenLabCmdError:
+                print("Check failed")
 
     @_zk_wrapper
     def ha_config_list(self):

--- a/openlabcmd/openlabcmd/cli.py
+++ b/openlabcmd/openlabcmd/cli.py
@@ -188,14 +188,14 @@ class OpenLabCmd(object):
         cmd_ha_service_get.set_defaults(func=self.ha_cluster_switch)
 
         # openlab ha cluster repair
-        cmd_ha_cluster_check = cmd_ha_cluster_subparsers.add_parser(
+        cmd_ha_cluster_repair = cmd_ha_cluster_subparsers.add_parser(
             'repair', help='HA deployment check and repair.')
-        cmd_ha_cluster_check.set_defaults(func=self.ha_cluster_check)
-        cmd_ha_cluster_check.add_argument(
+        cmd_ha_cluster_repair.set_defaults(func=self.ha_cluster_repair)
+        cmd_ha_cluster_repair.add_argument(
             '--security-group',
             help='Repair the Security Group of HA deployment.',
             action='store_true', required=True)
-        cmd_ha_cluster_check.add_argument(
+        cmd_ha_cluster_repair.add_argument(
             '--dry-run', help='Only report the check list of HA deployment,'
                               ' not try to repair if there is a check error.',
             action='store_true')
@@ -406,11 +406,12 @@ class OpenLabCmd(object):
             print("Switch failed")
     
     @_zk_wrapper
-    def ha_cluster_check(self):
-        # TODO(bz) This check may support other function
+    def ha_cluster_repair(self):
+        # TODO(bz) This repair may support other function
         if self.args.security_group:
             try:
-                self.zk.check_deployment_sg(is_dry_run=self.args.dry_run)
+                self.zk.check_and_repair_deployment_sg(
+                    is_dry_run=self.args.dry_run)
                 print("Check success")
             except exceptions.OpenLabCmdError:
                 print("Check failed")

--- a/openlabcmd/openlabcmd/constants.py
+++ b/openlabcmd/openlabcmd/constants.py
@@ -1,0 +1,13 @@
+# openlabcmd ha cluster repair requests
+RSYNCD_HA_PORT = 873
+ZOOKEEPER_HA_PORTS = [2181, 2888, 3888]
+MYSQL_HA_PORT = 3306
+
+HA_PORTS = []
+for ports in [RSYNCD_HA_PORT, ZOOKEEPER_HA_PORTS, MYSQL_HA_PORT]:
+    if isinstance(ports, list):
+        HA_PORTS.extend(ports)
+    else:
+        HA_PORTS.append(ports)
+
+HA_SGs = ['openlab-ha-ports']

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -378,8 +378,8 @@ class ZooKeeper(object):
                 self.update_node(node.name, switch_status='start')
 
     @_client_check_wrapper
-    def check_deployment_sg(self, is_dry_run=False):
-        """Repair current HA deployment Security Group configuration
+    def check_and_repair_deployment_sg(self, is_dry_run=False):
+        """Check and Repair current HA deployment Security Group configuration
 
         This func is called by labkeeper deploy tool. So that operators can
         check and repair exist deployment from zookeeper. The function is

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -1,4 +1,5 @@
 import configparser
+import copy
 import datetime
 import json
 import logging
@@ -7,6 +8,7 @@ import time
 from kazoo.client import KazooClient, KazooState
 from kazoo import exceptions as kze
 from kazoo.handlers.threading import KazooTimeoutError
+import os_client_config
 
 from openlabcmd import exceptions
 from openlabcmd import node
@@ -373,6 +375,196 @@ class ZooKeeper(object):
         for node in self.list_nodes():
             if node.type != 'zookeeper':
                 self.update_node(node.name, switch_status='start')
+
+    @_client_check_wrapper
+    def check_deployment(self, is_dry_run=False):
+        """Check Current HA deployment peripheral configuration
+
+        This func is called by labkeeper deploy tool. So that operators can
+        check exist deployment from zookeeper. The check will including Cloud
+        Security Group configuration for now.
+        """
+        RSYNCD_HA_PORT = 873
+        ZOOKEEPER_HA_PORTS = [2181, 2888, 3888]
+        MYSQL_HA_PORT = 3306
+
+        HA_PORTS = []
+        for ports in [RSYNCD_HA_PORT, ZOOKEEPER_HA_PORTS, MYSQL_HA_PORT]:
+            if isinstance(ports, list):
+                HA_PORTS.extend(ports)
+            else:
+                HA_PORTS.append(ports)
+        deploy_map = {}
+        cloud_provide_rules = {}
+        unexpect_rules = {}
+        for node in self.list_nodes():
+            ha_ports_cp = copy.deepcopy(HA_PORTS)
+            if node.type == 'nodepool':
+                ha_ports_cp.remove(MYSQL_HA_PORT)
+            elif node.type == 'zuul':
+                for p in ZOOKEEPER_HA_PORTS:
+                    ha_ports_cp.remove(p)
+            elif node.type == 'zookeeper':
+                ha_ports_cp.remove(RSYNCD_HA_PORT)
+                ha_ports_cp.remove(MYSQL_HA_PORT)
+            if node.name.split("-")[0] not in deploy_map:
+                deploy_map[node.name.split("-")[0]] = {'nodes': [node]}
+                cloud_provide_rules[node.name.split("-")[0]] = {
+                    node.ip + '/32': ha_ports_cp}
+            else:
+                deploy_map[node.name.split("-")[0]]['nodes'].append(node)
+                cloud_provide_rules[node.name.split("-")[0]][
+                    node.ip + '/32'] = ha_ports_cp
+
+        # Fit current expect_rules
+        expect_rules = {}
+        sg_map = {}
+        cloud_names = list(cloud_provide_rules.keys())
+        for cloud_name, ip_dict in cloud_provide_rules.items():
+            c_names = copy.deepcopy(cloud_names)
+            c_names.remove(cloud_name)
+            expect_rules[cloud_name] = copy.deepcopy(ip_dict)
+            if len(cloud_provide_rules[cloud_name].keys()) > 1:
+                for c_name in c_names:
+                    expect_rules[cloud_name].update(
+                        copy.deepcopy(cloud_provide_rules[c_name]))
+            else:
+                for c_name in c_names:
+                    for ip in cloud_provide_rules[c_name].keys():
+                        if 2888 in cloud_provide_rules[c_name][ip]:
+                            zk_ha_ports = copy.deepcopy(ZOOKEEPER_HA_PORTS)
+                            expect_rules[cloud_name][ip] = zk_ha_ports
+                        else:
+                            expect_rules[cloud_name][ip] = [2181]
+
+        HA_SGs = ['openlab-ha-ports']
+        for cloud_name, nodes_dict in deploy_map.items():
+            net_client = os_client_config.make_rest_client(
+                'network', cloud=cloud_name)
+            for sg_name in HA_SGs:
+                url = "/security-groups?name=%s" % sg_name
+                resp = net_client.get(url)
+                if resp.status_code != 200:
+                    raise exceptions.ClientError(
+                        'Security group %(sg_name)s not found on '
+                        'cloud %(cloud_name)s.' % {'sg_name': sg_name,
+                                                   'cloud_name': cloud_name})
+                sgr_data = resp.json()['security_groups'][0]
+                if cloud_name not in sg_map:
+                    sg_map[cloud_name] = resp.json()[
+                        'security_groups'][0]['id']
+                for rule in sgr_data['security_group_rules']:
+                    if rule['direction'] != 'ingress':
+                        continue
+
+                    is_specified_1_port = (
+                            rule['port_range_min'] == rule['port_range_max'])
+                    is_ipv4 = rule['ethertype'] == 'IPv4'
+                    is_tcp = rule['protocol'] == 'tcp'
+
+                    if not expect_rules[cloud_name].get(
+                            rule['remote_ip_prefix']):
+                        if cloud_name not in unexpect_rules:
+                            unexpect_rules[cloud_name] = [
+                                (rule['remote_ip_prefix'],
+                                 rule['port_range_min'], rule['id'])]
+                        else:
+                            unexpect_rules[cloud_name].append(
+                                (rule['remote_ip_prefix'],
+                                 rule['port_range_min'], rule['id']))
+                    else:
+                        if (is_specified_1_port and is_ipv4 and is_tcp and
+                                rule['port_range_min'] in expect_rules[
+                                    cloud_name][rule['remote_ip_prefix']]):
+                            expect_rules[cloud_name][
+                                rule['remote_ip_prefix']].remove(
+                                rule['port_range_min'])
+                            if len(expect_rules[cloud_name][
+                                       rule['remote_ip_prefix']]) ==0:
+                                expect_rules[cloud_name].pop(
+                                    rule['remote_ip_prefix'])
+                                print("POOP remove %s, %s" % (
+                                    cloud_name, rule['remote_ip_prefix']))
+                        else:
+                            if cloud_name not in unexpect_rules:
+                                unexpect_rules[cloud_name] = [
+                                    (rule['remote_ip_prefix'],
+                                     rule['port_range_min'], rule['id'])]
+                            else:
+                                unexpect_rules[cloud_name].append((
+                                    rule['remote_ip_prefix'],
+                                    rule['port_range_min'], rule['id']))
+
+        if not is_dry_run:
+            # analysis expect_rules
+            for cloud_name, ip_dict in expect_rules.items():
+                if not ip_dict:
+                    continue
+
+                print("Recover security group rules for cloud %s:" %
+                      cloud_name)
+                # Here means the sg lacks SG_rule settings
+                net_client = os_client_config.make_rest_client(
+                    'network', cloud=cloud_name)
+                for ip, ports in ip_dict.items():
+                    req = {
+                        "security_group_rule": {
+                            "direction": "ingress",
+                            "ethertype": "IPv4",
+                            "protocol": "tcp",
+                            "security_group_id": sg_map[cloud_name],
+                            "remote_ip_prefix": ip
+                        }
+                    }
+                    for port in ports:
+                        req["security_group_rule"].update({
+                            "port_range_min": port,
+                            "port_range_max": port
+                        })
+                        net_client.post('/security-group-rules', json=req)
+                        print("Create new sg_rule, summary %(ip)s %(port)s" % {
+                            "ip": ip,
+                            "port": str(port)
+                        })
+
+            # remove unexpect sg_rules
+            for cloud_name, ip_port_tuple_list in unexpect_rules.items():
+                net_client = os_client_config.make_rest_client(
+                    'network', cloud=cloud_name)
+                print("Unexpect security group rules clean for cloud %s:" %
+                      cloud_name)
+                for ip_port_tuple in ip_port_tuple_list:
+                    url = "/security-group-rules/%s" % ip_port_tuple[2]
+                    net_client.delete(url)
+                    print("Remove sg_rule %(rule_id)s, summary %(ip)s "
+                          "%(port)s" % {
+                        "rule_id": ip_port_tuple[2],
+                        "ip": ip_port_tuple[0],
+                        "port": str(ip_port_tuple[1])
+                    })
+        else:
+            for cloud_name, ip_dict in expect_rules.items():
+                if not ip_dict:
+                    continue
+                print("Found lack security group rules in cloud %s" %
+                      cloud_name)
+                for ip, ports in ip_dict.items():
+                    print("    Need to create new rule for (ip)s (ports)s" % {
+                        "ip": ip,
+                        "ports": str(ports)
+                    })
+
+            # remove unexpect sg_rules
+            for cloud_name, ip_port_tuple_list in unexpect_rules.items():
+                print("Found unexpect security group rules clean for "
+                      "cloud %s:" % cloud_name)
+                for ip_port_tuple in ip_port_tuple_list:
+                    print("    Need to remove sg_rule %(rule_id)s, "
+                          "summary %(ip)s %(port)s" % {
+                        "rule_id": ip_port_tuple[2],
+                        "ip": ip_port_tuple[0],
+                        "port": str(ip_port_tuple[1])
+                    })
 
     def _init_ha_configuration(self):
         path = '/ha/configuration'

--- a/openlabcmd/requirements.txt
+++ b/openlabcmd/requirements.txt
@@ -2,6 +2,7 @@ configparser
 enum;python_version=='2.7'
 kazoo
 openstackclient
+os-client-config
 pbr>=1.3
 prettytable
 pytz


### PR DESCRIPTION
This PR add a ha check cli for checking existing node SG configuration.

summary:
openlab ha cluster repair --security-group
This cmd will try to check and repair the SG if find errors.

openlab ha cluster repair --security-group --dry-run
This cmd will only check the SG of existing nodes.

If we launch a new HA deployment, such as new-slave. We can just run this cmd(if the deployment cloud already contains SG 'openlab-ha-ports'), it will fix the all ha related SG rules automatically.

Related-Bug: theopenlab/openlab#218