### PR TITLE
Add configurable service restart count

### DIFF
--- a/ha_healthchecker/ha_healthchecker/action/refresher.py
+++ b/ha_healthchecker/ha_healthchecker/action/refresher.py
@@ -18,9 +18,7 @@ class Refresher(base.Action):
         cur_status = self._get_service_status(service_obj.name)
         update_dict = {}
         if cur_status == 'up':
-            if (service_obj.status != 'up' and
-                    service_obj.restarted_count <
-                    self.cluster_config.service_count_allow_to_raise):
+            if service_obj.status != 'up':
                 update_dict['status'] = 'up'
                 update_dict['restarted'] = False
                 update_dict['alarmed'] = False
@@ -35,15 +33,15 @@ class Refresher(base.Action):
                 self.LOG.debug("Service %(name)s is Restarting.",
                                {'name': service_obj.name})
             else:
-                if (service_obj.restarted_count >
-                        self.cluster_config.service_count_allow_to_raise):
+                if (service_obj.restarted_count >=
+                        self.cluster_config.service_restart_max_times):
                     update_dict['status'] = 'down'
                     self.LOG.debug("Service %(name)s is Down.",
                                    {'name': service_obj.name})
                 else:
                     update_dict[
                         'restarted_account'] = service_obj.restarted_count + 1
-                    self.LOG.debug("Service %(name)s continue in Restarting, "
+                    self.LOG.debug("Service %(name)s continue in restarting, "
                                    "tried %(count)s times",
                                    {'name': service_obj.name,
                                     'count': service_obj.restarted_count})

--- a/openlabcmd/openlabcmd/service.py
+++ b/openlabcmd/openlabcmd/service.py
@@ -53,7 +53,7 @@ class Service(object):
     def __init__(self, name, node_name, alarmed=None,
                  alarmed_at=None, restarted=None, restarted_at=None,
                  is_necessary=None, status=None, created_at=None,
-                 updated_at=None, **kwargs):
+                 updated_at=None, restarted_count=None, **kwargs):
         self.name = name
         self.node_name = node_name
         self.alarmed = alarmed or False
@@ -64,6 +64,7 @@ class Service(object):
         self.status = status or ServiceStatus.INITIALIZING
         self.created_at = created_at
         self.updated_at = updated_at
+        self.restarted_count = restarted_count or 0
 
     def to_zk_bytes(self):
         node_dict = {
@@ -74,7 +75,8 @@ class Service(object):
             'restarted': self.restarted,
             'restarted_at': self.restarted_at,
             'is_necessary': self.is_necessary,
-            'status': self.status
+            'status': self.status,
+            'restarted_account': self.restarted_count
         }
         return json.dumps(node_dict).encode('utf8')
 

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -29,7 +29,7 @@ CONFIGURATION_DICT = {
     'github_user_token': None,
     'heartbeat_timeout_second': 600,
     'logging_level': 'DEBUG',
-    'service_count_allow_to_raise': 3,
+    'service_restart_max_times': 3,
     'unnecessary_service_switch_timeout_hour': 48,
 }
 

--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -29,6 +29,7 @@ CONFIGURATION_DICT = {
     'github_user_token': None,
     'heartbeat_timeout_second': 600,
     'logging_level': 'DEBUG',
+    'service_count_allow_to_raise': 3,
     'unnecessary_service_switch_timeout_hour': 48,
 }
 


### PR DESCRIPTION
1. Add new attr 'restarted_count' into service obj
2. Add new option 'service_count_allow_to_raise' into cluster
configuration, default is 3.

Then the restart service operation will delay for 3 times, if the last
status is still down, the logic will set the service status down in zk.

Related-Bug: theopenlab/openlab#218