### PR TITLE
Give zuul job more space

### DIFF
--- a/etc/zuul/zuul.conf.j2
+++ b/etc/zuul/zuul.conf.j2
@@ -24,7 +24,7 @@ state_dir = {{ zuul_user_home }}
 finger_port = 17979
 log_config = /etc/zuul/executor-logging.conf
 private_key_file = {{ zuul_user_home }}/.ssh/id_rsa
-disk_limit_per_job=1024
+disk_limit_per_job=2048
 load_multiplier=4
 
 [fingergw]


### PR DESCRIPTION
The source code of some projects is not small. Like percona-server, it's more than 800M, so its job always hits `DISK_FULL` error in zuul.

This pr make the limit larger to ensure the big project can be ran as well.