### PR TITLE
Remove experimental flag in network and sg

### DIFF
--- a/openlabcmd/openlabcmd/plugins/nodepool/network.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/network.py
@@ -7,7 +7,6 @@ from openlabcmd.plugins.recover import Recover
 class NetworkPlugin(Plugin):
     ptype = 'nodepool'
     name = 'network'
-    experimental = True
 
     def check(self):
         self.failed = False
@@ -32,7 +31,7 @@ class NetworkPlugin(Plugin):
             return
 
         # get subnet of openlab-net successfully, check subnet
-        if "openlab-subnet 192.168.199.0/24" not in res:
+        if "openlab-subnet 192.168.0.0/24" not in res:
             self.failed = True
             self.reasons.append(Recover.NETWORK_SUBNET)
             return

--- a/openlabcmd/openlabcmd/plugins/nodepool/securitygroup.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/securitygroup.py
@@ -8,7 +8,6 @@ class SecurityGroupPlugin(Plugin):
 
     ptype = 'nodepool'
     name = 'securitygroup'
-    experimental = True
 
     def check(self):
         self.failed = False

--- a/openlabcmd/openlabcmd/plugins/recover.py
+++ b/openlabcmd/openlabcmd/plugins/recover.py
@@ -37,12 +37,12 @@ RECOVER_MAPS = {
     },
     Recover.NETWORK_SUBNET: {
         "recover": "openstack --os-cloud %s subnet create openlab-subnet "
-                   "--network openlab-net --subnet-range=192.168.199.0/24",
+                   "--network openlab-net --subnet-range=192.168.0.0/24",
         "reason": "- Subnet: openlab-subnet is not found.",
     },
     Recover.NETWORK_SUBNET_CIDR: {
         "recover": "openstack --os-cloud %s subnet create openlab-subnet "
-                   "--network openlab-net --subnet-range=192.168.199.0/24",
-        "reason": "- Subnet cidr: 192.168.199.0/24 is not found.",
+                   "--network openlab-net --subnet-range=192.168.0.0/24",
+        "reason": "- Subnet cidr: 192.168.0.0/24 is not found.",
     },
 }


### PR DESCRIPTION
The Openlab env has been reformed. We are now happy to remove
the experimental flag for network and security group network.

This patch also fix the cidr in subnet, current all nodepool
vm are 192.168.0.X.

Close: https://github.com/theopenlab/openlab/issues/274