### PR TITLE
Add retry limit for zookeeper connection

### DIFF
--- a/openlabcmd/etc/openlab.conf
+++ b/openlabcmd/etc/openlab.conf
@@ -8,3 +8,4 @@ resource_timeout_hour = 24
 [ha]
 zookeeper_hosts = localhost
 zookeeper_connect_timeout = 5
+zookeeper_connect_retry_limit = 5


### PR DESCRIPTION
Do not retry forever for zookeeper connection. Add the limit,
the default value is 5.