### PR TITLE
 Refactor Router check

### DIFF
--- a/openlabcmd/openlabcmd/plugins/nodepool/network.py
+++ b/openlabcmd/openlabcmd/plugins/nodepool/network.py
@@ -78,7 +78,11 @@ class NetworkPlugin(Plugin):
         if ret != 0:
             self.failed = True
             self.reasons.append(Recover.ROUTER_SUBNET_INTERFACE)
-            if ext_net_id not in res:
+            router_ext_check = 'openstack --os-cloud %s router show ' \
+                               'openlab-router | grep %s' % (
+                                self.cloud, ext_net_id)
+            re_ret, re_res = subprocess.getstatusoutput(router_ext_check)
+            if re_ret != 0:
                 self.reasons.append(Recover.ROUTER_EXTERNAL_GW)
                 self.internal_recover_args_map[Recover.ROUTER_EXTERNAL_GW] = [
                     ext_net_id]


### PR DESCRIPTION
We check the ext-net first, if ext-net failed, we must contact the cloud
administrator to see, if no ext-net, create the router is useless for
us.
Then if cannot find a router, we will recover for creating a router,
interface attachment and gateway setting.
if find a router, but didn't find it had been attached into a specific
network, we will attach it into openlab-subnet, also if ext-net is not
setted on router, we will add it into recover process.