### PR TITLE
Clean up zk client if connect failed

### DIFF
--- a/openlabcmd/openlabcmd/zk.py
+++ b/openlabcmd/openlabcmd/zk.py
@@ -130,6 +130,7 @@ class ZooKeeper(object):
                     self.logConnectionRetryEvent()
                 tried_times += 1
                 if tried_times == retry_limit:
+                    self.client = None
                     raise exceptions.ClientError(
                         "Tried %s times, failed connecting "
                         "zookeeper." % retry_limit)


### PR DESCRIPTION
zk client obj should be cleaned up if connect failed so that it can be reconnected in the next loop.